### PR TITLE
No-reviewers login

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -10,4 +10,8 @@ class HomeController < ApplicationController
   def reviewer_signup
     redirect_to root_path if current_user
   end
+
+  def no_reviewer_signup
+    redirect_to reviewers_path if current_user
+  end
 end

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -7,7 +7,7 @@ class ProfilesController < ApplicationController
 
   def update
     if @user.update(profile_params)
-      redirect_to profile_path, notice: "Your profile was successfully updated."
+      redirect_back_or_to profile_path, notice: "Your profile was successfully updated."
     else
       render :show
     end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,6 +1,6 @@
 class SessionsController < ApplicationController
   def create
-    user = User.from_github_omniauth(request.env["omniauth.auth"])
+    user = User.from_github_omniauth(request.env["omniauth.auth"], request.env["omniauth.params"])
 
     session[:user_id] = user.id
     if request.env['omniauth.origin']

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,13 +15,13 @@ class User < ApplicationRecord
   scope :editors, -> { where(editor: true) }
   scope :admins, -> { where(admin: true) }
 
-  def self.from_github_omniauth(auth)
+  def self.from_github_omniauth(auth, params={})
     if never_logged_in_user = where(github: auth.info.nickname, github_uid: nil).first
       never_logged_in_user.email = auth.info.email
       never_logged_in_user.github_uid = auth.uid
       never_logged_in_user.github_avatar_url = auth.info.image
       never_logged_in_user.github_token = auth.credentials.token
-      never_logged_in_user.reviewer = true
+      never_logged_in_user.reviewer = true unless params["reviewer"].presence == "no"
       never_logged_in_user.save
       never_logged_in_user
     else
@@ -30,7 +30,7 @@ class User < ApplicationRecord
         user.github = auth.info.nickname
         user.github_avatar_url = auth.info.image
         user.github_token = auth.credentials.token
-        user.reviewer = true
+        user.reviewer = true unless params["reviewer"].presence == "no"
         user.save
       end
     end

--- a/app/views/home/no_reviewer_signup.html.erb
+++ b/app/views/home/no_reviewer_signup.html.erb
@@ -1,0 +1,19 @@
+<div class="justify-content-lg-center px-9">
+  <div class="block text-center mb-2">
+    <%= image_tag "logo_header.png", class: "block mx-auto w-72 sm:shrink-0" %>
+    <h2>Journal of Open Source Software :: Reviewers</h2>
+  </div>
+
+  <p class="block text-center text-lg">
+  Sign up here if you want to help find potential reviewers for a JOSS review.
+  </p>
+
+  <div class="block mx-auto max-w-fit my-12 text-lg">
+    <ul class="list-disc">
+      <li>
+        <%= button_to "Log in with your GitHub user", "/auth/github?reviewer=no", method: :post, data: { turbo: false }, class: "link-styled" %>
+      </li>
+
+    </ul>
+  </div>
+</div>

--- a/app/views/home/user_home.html.erb
+++ b/app/views/home/user_home.html.erb
@@ -1,6 +1,14 @@
 <div class="justify-content-lg-center px-9">
   <p class="my-2 text-lg">Hi <%= current_user.complete_name.presence || "@" + current_user.github %></p>
 
+  <% unless current_user.reviewer %>
+    <p class="my-2">Your current status is: <strong>not available to review</strong>.</p>
+
+    <p class="my-2">
+      <%= button_to "Mark me as available to review", profile_path, method: :put, params: {user: {reviewer: true}}, data: { turbo: false }, class: "btn-primary" %>
+    </p>
+  <% end %>
+
   <% if current_user.reviewer && !current_user.profile_complete? %>
     <p class="my-2 text-lg">Thanks for signing up as a reviewer!</p>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,5 +36,6 @@ Rails.application.routes.draw do
   resources :feedbacks, only: [:create, :destroy]
 
   get '/join', to: 'home#reviewer_signup', as: :reviewer_signup
+  get '/lookup', to: 'home#no_reviewer_signup', as: :no_reviewer_signup
   root to: 'home#index'
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -180,7 +180,7 @@ RSpec.describe User, type: :model do
       user = create(:user, github_uid: "123456", email: "user@ema.il")
 
       expect {
-        returned_user = User.from_github_omniauth(auth_info)
+        returned_user = User.from_github_omniauth(auth_info, {})
 
         expect(returned_user).to eq(user)
         expect(returned_user.email).to eq("user@ema.il")
@@ -216,6 +216,19 @@ RSpec.describe User, type: :model do
         expect(logged_user.id).to eq(user.id)
         expect(logged_user.affiliation).to eq("Scilab")
       }.to_not change { User.count }
+    end
+
+    it "allows skipping marking user as available to review" do
+      expect {
+        new_user = User.from_github_omniauth(auth_info, {"reviewer" => "no"})
+
+        expect(new_user.github_uid).to eq("123456")
+        expect(new_user.github).to eq("test-auth-user")
+        expect(new_user.email).to eq("auth@test.ing")
+        expect(new_user.github_avatar_url).to eq("/authtest_avatar.png")
+        expect(new_user.github_token).to eq("abcdefg")
+        expect(new_user.reviewer).to eq(false)
+      }.to change { User.count }.by(1)
     end
   end
 end

--- a/spec/system/home_spec.rb
+++ b/spec/system/home_spec.rb
@@ -53,6 +53,25 @@ RSpec.describe "Home", type: :system do
     end
   end
 
+  describe "/lookup" do
+    scenario "prompts users to sign up skipping marking them as reviewers" do
+      visit no_reviewer_signup_path
+      expect(page).to have_selector("form.button_to[@action='/auth/github?reviewer=no']")
+
+      within("form.button_to[@action='/auth/github?reviewer=no']") do
+        expect(page).to have_button("Log in with your GitHub user")
+      end
+      expect(page).to have_content("help find potential reviewers")
+      expect(page).to_not have_link("Log out")
+    end
+
+    scenario "redirects to home if user is already logged in" do
+      login_as(create(:user))
+      visit no_reviewer_signup_path
+      expect(page).to have_current_path(reviewers_path)
+    end
+  end
+
   describe "for reviewers" do
     scenario "prompt user to complete profile in missing info" do
       reviewer = create(:reviewer, complete_name: nil, areas: [])

--- a/spec/system/home_spec.rb
+++ b/spec/system/home_spec.rb
@@ -82,7 +82,33 @@ RSpec.describe "Home", type: :system do
     end
 
     scenario "list info if reviewer's profile is complete" do
+      reviewer = create(:reviewer, complete_name: "Vera", email: "vera@rub.in", affiliation: "Georgetown", areas: [create(:area, name: "Astronomy")], domains: "galaxies,dark matter" )
+      login_as reviewer
+      visit root_path
 
+      expect(page).to have_content("You are listed as reviewer for")
+      expect(page).to have_content("Astronomy")
+      expect(page).to have_content("with expertise in galaxies and dark matter")
+      expect(page).to_not have_content("Please complete your profile")
+    end
+  end
+
+  describe "for no reviewers" do
+    scenario "allow users to mark themselves as available to review" do
+      no_reviewer = create(:user)
+      login_as no_reviewer
+      visit root_path
+
+      expect(page).to have_content("Your current status is: not available to review.")
+      expect(page).to have_button("Mark me as available to review")
+      expect(page).to_not have_content("Please complete your profile")
+
+      click_button("Mark me as available to review")
+
+      expect(page).to have_current_path(root_path)
+      expect(page).to have_content("Your profile was successfully updated.")
+      expect(page).to have_content("Thanks for signing up as a reviewer!")
+      expect(page).to_not have_content("Your current status is: not available to review.")
     end
   end
 end


### PR DESCRIPTION
This PR adds a signup page for users wanting only to lookup for reviewers (for instance authors of paper submissions trying to find suggestions for potential reviewers of their paper). This sign up won't mark the new user as available for review.